### PR TITLE
add concordance table

### DIFF
--- a/src/bblocks_places/concordance.csv
+++ b/src/bblocks_places/concordance.csv
@@ -1,0 +1,251 @@
+﻿name,name_short,iso2_code,iso3_code,iso_numeric_code,m49_code,m49_region_code,m49_region_name,m49_subregion_code,m49_subregion_name,m49_member,m49_intermediate_region_code,m49_intermediate_region_name,ldc,lldc,sids,un_member,un_observer,un_former_member,dac_code,income_level
+Afghanistan,Afghanistan,AF,AFG,4,4,142,Asia,34,Southern Asia,TRUE,,,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,625,Low & middle income
+Åland Islands,Åland Islands,AX,ALA,248,248,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Albania,Albania,AL,ALB,8,8,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,71,Upper middle income
+Algeria,Algeria,DZ,DZA,12,12,2,Africa,15,Northern Africa,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,130,Upper middle income
+American Samoa,American Samoa,AS,ASM,16,16,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,880,High income
+Andorra,Andorra,AD,AND,20,20,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,,High income
+Angola,Angola,AO,AGO,24,24,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,225,Middle income
+Anguilla,Anguilla,AI,AIA,660,660,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,
+Antarctica,Antarctica,AQ,ATA,10,10,,,,,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Antigua and Barbuda,Antigua and Barbuda,AG,ATG,28,28,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,377,High income
+Argentina,Argentina,AR,ARG,32,32,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,425,Upper middle income
+Armenia,Armenia,AM,ARM,51,51,142,Asia,145,Western Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,610,Upper middle income
+Aruba,Aruba,AW,ABW,533,533,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+Australia,Australia,AU,AUS,36,36,9,Oceania,53,Australia and New Zealand,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,801,High income
+Austria,Austria,AT,AUT,40,40,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,1,High income
+Azerbaijan,Azerbaijan,AZ,AZE,31,31,142,Asia,145,Western Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,611,Upper middle income
+Bahamas,Bahamas,BS,BHS,44,44,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,,High income
+Bahrain,Bahrain,BH,BHR,48,48,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,,High income
+Bangladesh,Bangladesh,BD,BGD,50,50,142,Asia,34,Southern Asia,TRUE,,,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,666,Middle income
+Barbados,Barbados,BB,BRB,52,52,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,,High income
+Belarus,Belarus,BY,BLR,112,112,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,86,Upper middle income
+Belgium,Belgium,BE,BEL,56,56,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,2,High income
+Belize,Belize,BZ,BLZ,84,84,19,Americas,419,Latin America and the Caribbean,TRUE,13,Central America,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,352,Upper middle income
+Benin,Benin,BJ,BEN,204,204,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,236,Middle income
+Bermuda,Bermuda,BM,BMU,60,60,19,Americas,21,Northern America,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Bhutan,Bhutan,BT,BTN,64,64,142,Asia,34,Southern Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,630,Middle income
+Bolivia (Plurinational State of),Bolivia,BO,BOL,68,68,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,428,Middle income
+"Bonaire, Sint Eustatius and Saba","Bonaire, Saint Eustatius and Saba",BQ,BES,535,535,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,
+Bosnia and Herzegovina,Bosnia and Herzegovina,BA,BIH,70,70,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,64,Upper middle income
+Botswana,Botswana,BW,BWA,72,72,2,Africa,202,Sub-Saharan Africa,TRUE,18,Southern Africa,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,227,Upper middle income
+Bouvet Island,Bouvet Island,BV,BVT,74,74,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Brazil,Brazil,BR,BRA,76,76,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,431,Upper middle income
+British Indian Ocean Territory,British Indian Ocean Territory,IO,IOT,86,86,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+British Virgin Islands,British Virgin Islands,VG,VGB,92,92,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+Brunei Darussalam,Brunei Darussalam,BN,BRN,96,96,142,Asia,35,South-eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,,High income
+Bulgaria,Bulgaria,BG,BGR,100,100,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,72,High income
+Burkina Faso,Burkina Faso,BF,BFA,854,854,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,287,Low & middle income
+Burundi,Burundi,BI,BDI,108,108,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,228,Low & middle income
+Cabo Verde,Cabo Verde,CV,CPV,132,132,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,230,Middle income
+Cambodia,Cambodia,KH,KHM,116,116,142,Asia,35,South-eastern Asia,TRUE,,,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,728,Middle income
+Cameroon,Cameroon,CM,CMR,120,120,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,229,Middle income
+Canada,Canada,CA,CAN,124,124,19,Americas,21,Northern America,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,301,High income
+Cayman Islands,Cayman Islands,KY,CYM,136,136,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Central African Republic,Central African Republic,CF,CAF,140,140,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,231,Low & middle income
+Chad,Chad,TD,TCD,148,148,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,232,Low & middle income
+Chile,Chile,CL,CHL,152,152,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,,High income
+China,China,CN,CHN,156,156,142,Asia,30,Eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,730,Upper middle income
+"China, Hong Kong Special Administrative Region",Hong Kong,HK,HKG,344,344,142,Asia,30,Eastern Asia,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+"China, Macao Special Administrative Region",Macau,MO,MAC,446,446,142,Asia,30,Eastern Asia,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Christmas Island,Christmas Island,CX,CXR,162,162,9,Oceania,53,Australia and New Zealand,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Cocos (Keeling) Islands,Cocos (Keeling) Islands,CC,CCK,166,166,9,Oceania,53,Australia and New Zealand,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Colombia,Colombia,CO,COL,170,170,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,437,Upper middle income
+Comoros,Comoros,KM,COM,174,174,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,FALSE,TRUE,TRUE,FALSE,FALSE,233,Middle income
+Congo,Congo,CG,COG,178,178,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,234,Middle income
+Cook Islands,Cook Islands,CK,COK,184,184,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,
+Costa Rica,Costa Rica,CR,CRI,188,188,19,Americas,419,Latin America and the Caribbean,TRUE,13,Central America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,336,Upper middle income
+Côte d’Ivoire,Côte d’Ivoire,CI,CIV,384,384,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,247,Middle income
+Croatia,Croatia,HR,HRV,191,191,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,62,High income
+Cuba,Cuba,CU,CUB,192,192,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,338,Upper middle income
+Curaçao,Curaçao,CW,CUW,531,531,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+Cyprus,Cyprus,CY,CYP,196,196,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,30,High income
+Czechia,Czechia,CZ,CZE,203,203,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,68,High income
+Democratic People's Republic of Korea,North Korea,KP,PRK,408,408,142,Asia,30,Eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,740,Low & middle income
+Democratic Republic of the Congo,DR Congo,CD,COD,180,180,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,235,Low & middle income
+Denmark,Denmark,DK,DNK,208,208,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,3,High income
+Djibouti,Djibouti,DJ,DJI,262,262,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,274,Middle income
+Dominica,Dominica,DM,DMA,212,212,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,378,Upper middle income
+Dominican Republic,Dominican Republic,DO,DOM,214,214,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,340,Upper middle income
+Ecuador,Ecuador,EC,ECU,218,218,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,440,Upper middle income
+Egypt,Egypt,EG,EGY,818,818,2,Africa,15,Northern Africa,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,142,Middle income
+El Salvador,El Salvador,SV,SLV,222,222,19,Americas,419,Latin America and the Caribbean,TRUE,13,Central America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,342,Upper middle income
+Equatorial Guinea,Equatorial Guinea,GQ,GNQ,226,226,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,245,Upper middle income
+Eritrea,Eritrea,ER,ERI,232,232,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,271,Low & middle income
+Estonia,Estonia,EE,EST,233,233,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,82,High income
+Eswatini,Eswatini,SZ,SWZ,748,748,2,Africa,202,Sub-Saharan Africa,TRUE,18,Southern Africa,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,280,Middle income
+Ethiopia,Ethiopia,ET,ETH,231,231,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,238,Low & middle income
+Falkland Islands (Malvinas),Falkland Islands,FK,FLK,238,238,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Faroe Islands,Faroe Islands,FO,FRO,234,234,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Fiji,Fiji,FJ,FJI,242,242,9,Oceania,54,Melanesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,832,Upper middle income
+Finland,Finland,FI,FIN,246,246,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,18,High income
+France,France,FR,FRA,250,250,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,4,High income
+French Guiana,French Guiana,GF,GUF,254,254,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+French Polynesia,French Polynesia,PF,PYF,258,258,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+French Southern Territories,French Southern Territories,TF,ATF,260,260,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Gabon,Gabon,GA,GAB,266,266,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,239,Upper middle income
+Gambia,Gambia,GM,GMB,270,270,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,240,Low & middle income
+Georgia,Georgia,GE,GEO,268,268,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,612,Upper middle income
+Germany,Germany,DE,DEU,276,276,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,5,High income
+Ghana,Ghana,GH,GHA,288,288,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,241,Middle income
+Gibraltar,Gibraltar,GI,GIB,292,292,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Greece,Greece,GR,GRC,300,300,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,40,High income
+Greenland,Greenland,GL,GRL,304,304,19,Americas,21,Northern America,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Grenada,Grenada,GD,GRD,308,308,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,381,Upper middle income
+Guadeloupe,Guadeloupe,GP,GLP,312,312,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Guam,Guam,GU,GUM,316,316,9,Oceania,57,Micronesia,TRUE,,,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+Guatemala,Guatemala,GT,GTM,320,320,19,Americas,419,Latin America and the Caribbean,TRUE,13,Central America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,347,Upper middle income
+Guernsey,Guernsey,GG,GGY,831,831,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Guinea,Guinea,GN,GIN,324,324,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,243,Middle income
+Guinea-Bissau,Guinea-Bissau,GW,GNB,624,624,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,TRUE,TRUE,FALSE,FALSE,244,Low & middle income
+Guyana,Guyana,GY,GUY,328,328,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,446,High income
+Haiti,Haiti,HT,HTI,332,332,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,TRUE,FALSE,TRUE,TRUE,FALSE,FALSE,349,Middle income
+Heard Island and McDonald Islands,Heard and McDonald Islands,HM,HMD,334,334,9,Oceania,53,Australia and New Zealand,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Holy See,Holy See,VA,VAT,336,336,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,FALSE,TRUE,FALSE,,
+Honduras,Honduras,HN,HND,340,340,19,Americas,419,Latin America and the Caribbean,TRUE,13,Central America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,351,Middle income
+Hungary,Hungary,HU,HUN,348,348,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,75,High income
+Iceland,Iceland,IS,ISL,352,352,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,20,High income
+India,India,IN,IND,356,356,142,Asia,34,Southern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,645,Middle income
+Indonesia,Indonesia,ID,IDN,360,360,142,Asia,35,South-eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,738,Upper middle income
+Iran (Islamic Republic of),Iran,IR,IRN,364,364,142,Asia,34,Southern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,540,Upper middle income
+Iraq,Iraq,IQ,IRQ,368,368,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,543,Upper middle income
+Ireland,Ireland,IE,IRL,372,372,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,21,High income
+Isle of Man,Isle of Man,IM,IMN,833,833,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Israel,Israel,IL,ISR,376,376,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,546,High income
+Italy,Italy,IT,ITA,380,380,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,6,High income
+Jamaica,Jamaica,JM,JAM,388,388,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,354,Upper middle income
+Japan,Japan,JP,JPN,392,392,142,Asia,30,Eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,701,High income
+Jersey,Jersey,JE,JEY,832,832,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Jordan,Jordan,JO,JOR,400,400,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,549,Middle income
+Kazakhstan,Kazakhstan,KZ,KAZ,398,398,142,Asia,143,Central Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,613,Upper middle income
+Kenya,Kenya,KE,KEN,404,404,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,248,Middle income
+Kiribati,Kiribati,KI,KIR,296,296,9,Oceania,57,Micronesia,TRUE,,,TRUE,FALSE,TRUE,TRUE,FALSE,FALSE,836,Middle income
+Kosovo,Kosovo,XK,XKX,,412,150,Europe,39,Southern Europe,FALSE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,57,Upper middle income
+Kuwait,Kuwait,KW,KWT,414,414,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,552,High income
+Kyrgyzstan,Kyrgyzstan,KG,KGZ,417,417,142,Asia,143,Central Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,614,Middle income
+Lao People's Democratic Republic,Laos,LA,LAO,418,418,142,Asia,35,South-eastern Asia,TRUE,,,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,745,Middle income
+Latvia,Latvia,LV,LVA,428,428,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,83,High income
+Lebanon,Lebanon,LB,LBN,422,422,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,555,Middle income
+Lesotho,Lesotho,LS,LSO,426,426,2,Africa,202,Sub-Saharan Africa,TRUE,18,Southern Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,249,Middle income
+Liberia,Liberia,LR,LBR,430,430,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,251,Low & middle income
+Libya,Libya,LY,LBY,434,434,2,Africa,15,Northern Africa,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,133,Upper middle income
+Liechtenstein,Liechtenstein,LI,LIE,438,438,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,70,High income
+Lithuania,Lithuania,LT,LTU,440,440,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,84,High income
+Luxembourg,Luxembourg,LU,LUX,442,442,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,22,High income
+Madagascar,Madagascar,MG,MDG,450,450,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,252,Low & middle income
+Malawi,Malawi,MW,MWI,454,454,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,253,Low & middle income
+Malaysia,Malaysia,MY,MYS,458,458,142,Asia,35,South-eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,751,Upper middle income
+Maldives,Maldives,MV,MDV,462,462,142,Asia,34,Southern Asia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,655,Upper middle income
+Mali,Mali,ML,MLI,466,466,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,255,Low & middle income
+Malta,Malta,MT,MLT,470,470,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,45,High income
+Marshall Islands,Marshall Islands,MH,MHL,584,584,9,Oceania,57,Micronesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,859,Upper middle income
+Martinique,Martinique,MQ,MTQ,474,474,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Mauritania,Mauritania,MR,MRT,478,478,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,256,Middle income
+Mauritius,Mauritius,MU,MUS,480,480,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,257,Upper middle income
+Mayotte,Mayotte,YT,MYT,175,175,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Mexico,Mexico,MX,MEX,484,484,19,Americas,419,Latin America and the Caribbean,TRUE,13,Central America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,358,Upper middle income
+Micronesia (Federated States of),Micronesia,FM,FSM,583,583,9,Oceania,57,Micronesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,860,Middle income
+Monaco,Monaco,MC,MCO,492,492,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,,High income
+Mongolia,Mongolia,MN,MNG,496,496,142,Asia,30,Eastern Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,753,Upper middle income
+Montenegro,Montenegro,ME,MNE,499,499,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,65,Upper middle income
+Montserrat,Montserrat,MS,MSR,500,500,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,385,
+Morocco,Morocco,MA,MAR,504,504,2,Africa,15,Northern Africa,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,136,Middle income
+Mozambique,Mozambique,MZ,MOZ,508,508,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,259,Low & middle income
+Myanmar,Myanmar,MM,MMR,104,104,142,Asia,35,South-eastern Asia,TRUE,,,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,635,Middle income
+Namibia,Namibia,,NAM,516,516,2,Africa,202,Sub-Saharan Africa,TRUE,18,Southern Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,275,Upper middle income
+Nauru,Nauru,NR,NRU,520,520,9,Oceania,57,Micronesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,845,High income
+Nepal,Nepal,NP,NPL,524,524,142,Asia,34,Southern Asia,TRUE,,,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,660,Middle income
+Netherlands (Kingdom of the),Netherlands,NL,NLD,528,528,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,7,High income
+New Caledonia,New Caledonia,NC,NCL,540,540,9,Oceania,54,Melanesia,TRUE,,,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+New Zealand,New Zealand,NZ,NZL,554,554,9,Oceania,53,Australia and New Zealand,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,820,High income
+Nicaragua,Nicaragua,NI,NIC,558,558,19,Americas,419,Latin America and the Caribbean,TRUE,13,Central America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,364,Middle income
+Niger,Niger,NE,NER,562,562,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,260,Low & middle income
+Nigeria,Nigeria,NG,NGA,566,566,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,261,Middle income
+Niue,Niue,NU,NIU,570,570,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,856,
+Norfolk Island,Norfolk Island,NF,NFK,574,574,9,Oceania,53,Australia and New Zealand,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+North Macedonia,North Macedonia,MK,MKD,807,807,150,Europe,39,Southern Europe,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,66,Upper middle income
+Northern Mariana Islands,Northern Mariana Islands,MP,MNP,580,580,9,Oceania,57,Micronesia,TRUE,,,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+Norway,Norway,NO,NOR,578,578,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,8,High income
+Oman,Oman,OM,OMN,512,512,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,,High income
+Pakistan,Pakistan,PK,PAK,586,586,142,Asia,34,Southern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,665,Middle income
+Palau,Palau,PW,PLW,585,585,9,Oceania,57,Micronesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,861,High income
+Panama,Panama,PA,PAN,591,591,19,Americas,419,Latin America and the Caribbean,TRUE,13,Central America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,366,High income
+Papua New Guinea,Papua New Guinea,PG,PNG,598,598,9,Oceania,54,Melanesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,862,Middle income
+Paraguay,Paraguay,PY,PRY,600,600,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,451,Upper middle income
+Peru,Peru,PE,PER,604,604,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,454,Upper middle income
+Philippines,Philippines,PH,PHL,608,608,142,Asia,35,South-eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,755,Middle income
+Pitcairn,Pitcairn,PN,PCN,612,612,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Poland,Poland,PL,POL,616,616,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,76,High income
+Portugal,Portugal,PT,PRT,620,620,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,9,High income
+Puerto Rico,Puerto Rico,PR,PRI,630,630,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+Qatar,Qatar,QA,QAT,634,634,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,561,High income
+Republic of Korea,South Korea,KR,KOR,410,410,142,Asia,30,Eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,742,High income
+Republic of Moldova,Moldova,MD,MDA,498,498,150,Europe,151,Eastern Europe,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,93,Upper middle income
+Réunion,Reunion,RE,REU,638,638,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Romania,Romania,RO,ROU,642,642,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,77,High income
+Russian Federation,Russia,RU,RUS,643,643,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,87,High income
+Rwanda,Rwanda,RW,RWA,646,646,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,266,Low & middle income
+Saint Barthélemy,St. Barths,BL,BLM,652,652,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Saint Helena,St. Helena,SH,SHN,654,654,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,276,
+Saint Kitts and Nevis,St. Kitts and Nevis,KN,KNA,659,659,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,,High income
+Saint Lucia,St. Lucia,LC,LCA,662,662,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,383,Upper middle income
+Saint Martin (French Part),Saint-Martin,MF,MAF,663,663,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Saint Pierre and Miquelon,St. Pierre and Miquelon,PM,SPM,666,666,19,Americas,21,Northern America,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Saint Vincent and the Grenadines,St. Vincent and the Grenadines,VC,VCT,670,670,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,384,Upper middle income
+Samoa,Samoa,WS,WSM,882,882,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,,Middle income
+San Marino,San Marino,SM,SMR,674,674,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,,High income
+Sao Tome and Principe,Sao Tome and Principe,ST,STP,678,678,2,Africa,202,Sub-Saharan Africa,TRUE,17,Middle Africa,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,268,Middle income
+Saudi Arabia,Saudi Arabia,SA,SAU,682,682,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,566,High income
+Senegal,Senegal,SN,SEN,686,686,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,269,Middle income
+Serbia,Serbia,RS,SRB,688,688,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,63,Upper middle income
+Seychelles,Seychelles,SC,SYC,690,690,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,,High income
+Sierra Leone,Sierra Leone,SL,SLE,694,694,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,272,Low & middle income
+Singapore,Singapore,SG,SGP,702,702,142,Asia,35,South-eastern Asia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,,High income
+Sint Maarten (Dutch part),Sint Maarten,SX,SXM,534,534,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+Slovakia,Slovakia,SK,SVK,703,703,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,69,High income
+Slovenia,Slovenia,SI,SVN,705,705,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,61,High income
+Solomon Islands,Solomon Islands,SB,SLB,90,90,9,Oceania,54,Melanesia,TRUE,,,TRUE,FALSE,TRUE,TRUE,FALSE,FALSE,866,Middle income
+Somalia,Somalia,SO,SOM,706,706,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,273,Low & middle income
+South Africa,South Africa,ZA,ZAF,710,710,2,Africa,202,Sub-Saharan Africa,TRUE,18,Southern Africa,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,218,Upper middle income
+South Georgia and the South Sandwich Islands,South Georgia and South Sandwich Is.,GS,SGS,239,239,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+South Sudan,South Sudan,SS,SSD,728,728,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,279,Low & middle income
+Spain,Spain,ES,ESP,724,724,150,Europe,39,Southern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,50,High income
+Sri Lanka,Sri Lanka,LK,LKA,144,144,142,Asia,34,Southern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,640,Middle income
+State of Palestine,Palestine,PS,PSE,275,275,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,FALSE,TRUE,FALSE,550,Middle income
+Sudan,Sudan,SD,SDN,729,729,2,Africa,15,Northern Africa,TRUE,,,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,278,Low & middle income
+Suriname,Suriname,SR,SUR,740,740,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,457,Upper middle income
+Svalbard and Jan Mayen Islands,Svalbard and Jan Mayen Islands,SJ,SJM,744,744,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Sweden,Sweden,SE,SWE,752,752,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,10,High income
+Switzerland,Switzerland,CH,CHE,756,756,150,Europe,155,Western Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,11,High income
+Syrian Arab Republic,Syria,SY,SYR,760,760,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,573,Low & middle income
+Taiwan,Taiwan,TW,TWN,158,158,142,Asia,30,Eastern Asia,FALSE,,,FALSE,FALSE,FALSE,FALSE,FALSE,TRUE,732,High income
+Tajikistan,Tajikistan,TJ,TJK,762,762,142,Asia,143,Central Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,615,Middle income
+Thailand,Thailand,TH,THA,764,764,142,Asia,35,South-eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,764,Upper middle income
+Timor-Leste,Timor-Leste,TL,TLS,626,626,142,Asia,35,South-eastern Asia,TRUE,,,TRUE,FALSE,TRUE,TRUE,FALSE,FALSE,765,Middle income
+Togo,Togo,TG,TGO,768,768,2,Africa,202,Sub-Saharan Africa,TRUE,11,Western Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,283,Low & middle income
+Tokelau,Tokelau,TK,TKL,772,772,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,868,
+Tonga,Tonga,TO,TON,776,776,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,870,Upper middle income
+Trinidad and Tobago,Trinidad and Tobago,TT,TTO,780,780,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,,High income
+Tunisia,Tunisia,TN,TUN,788,788,2,Africa,15,Northern Africa,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,139,Middle income
+Türkiye,Türkiye,TR,TUR,792,792,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,55,Upper middle income
+Turkmenistan,Turkmenistan,TM,TKM,795,795,142,Asia,143,Central Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,616,Upper middle income
+Turks and Caicos Islands,Turks and Caicos Islands,TC,TCA,796,796,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,High income
+Tuvalu,Tuvalu,TV,TUV,798,798,9,Oceania,61,Polynesia,TRUE,,,TRUE,FALSE,TRUE,TRUE,FALSE,FALSE,872,Upper middle income
+Uganda,Uganda,UG,UGA,800,800,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,285,Low & middle income
+Ukraine,Ukraine,UA,UKR,804,804,150,Europe,151,Eastern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,85,Upper middle income
+United Arab Emirates,United Arab Emirates,AE,ARE,784,784,142,Asia,145,Western Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,576,High income
+United Kingdom of Great Britain and Northern Ireland,United Kingdom,GB,GBR,826,826,150,Europe,154,Northern Europe,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,12,High income
+United Republic of Tanzania,Tanzania,TZ,TZA,834,834,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,282,Middle income
+United States Minor Outlying Islands,United States Minor Outlying Islands,UM,UMI,581,581,9,Oceania,57,Micronesia,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+United States of America,United States,US,USA,840,840,19,Americas,21,Northern America,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,302,High income
+United States Virgin Islands,United States Virgin Islands,VI,VIR,850,850,19,Americas,419,Latin America and the Caribbean,TRUE,29,Caribbean,FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,,High income
+Uruguay,Uruguay,UY,URY,858,858,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,,High income
+Uzbekistan,Uzbekistan,UZ,UZB,860,860,142,Asia,143,Central Asia,TRUE,,,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,617,Middle income
+Vanuatu,Vanuatu,VU,VUT,548,548,9,Oceania,54,Melanesia,TRUE,,,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,854,Middle income
+Venezuela (Bolivarian Republic of),Venezuela,VE,VEN,862,862,19,Americas,419,Latin America and the Caribbean,TRUE,5,South America,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,463,Not classified
+Viet Nam,Vietnam,VN,VNM,704,704,142,Asia,35,South-eastern Asia,TRUE,,,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,769,Middle income
+Wallis and Futuna Islands,Wallis and Futuna Islands,WF,WLF,876,876,9,Oceania,61,Polynesia,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,876,
+Western Sahara,Western Sahara,EH,ESH,732,732,2,Africa,15,Northern Africa,TRUE,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,
+Yemen,Yemen,YE,YEM,887,887,142,Asia,145,Western Asia,TRUE,,,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE,580,Low & middle income
+Zambia,Zambia,ZM,ZMB,894,894,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,TRUE,TRUE,FALSE,TRUE,FALSE,FALSE,288,Middle income
+Zimbabwe,Zimbabwe,ZW,ZWE,716,716,2,Africa,202,Sub-Saharan Africa,TRUE,14,Eastern Africa,FALSE,TRUE,FALSE,TRUE,FALSE,FALSE,265,Middle income


### PR DESCRIPTION
This PR adds a concordance table csv with country names and groupings
Includes:

- name
- short name
- m49 codes
- iso codes - 2,3,numeric
- DAC codes
- World Bank income groups
- Flags for UN member states and observing entities

In addition, entities `Taiwan` and `Kosovo` have been added as they appear in may datasets including those of the World Bank even though they are not recognised within the UN system