### PR TITLE
42 add convenience and public functions

### DIFF
--- a/src/bblocks/places/__init__.py
+++ b/src/bblocks/places/__init__.py
@@ -9,14 +9,12 @@ from bblocks.places.main import (
     get_ldc,
     get_lldc,
     get_african_countries,
-
     resolve_places,
     filter_places,
     resolve_places_mapping,
-
     filter_african_countries,
-    get_places_by
-                                 )
+    get_places_by,
+)
 
 
 __version__ = version("bblocks.places")

--- a/src/bblocks/places/main.py
+++ b/src/bblocks/places/main.py
@@ -4,14 +4,17 @@ This module will contain all the convenience functions and wrappers
 that a user can access
 
 """
+
 from bblocks.places.resolver import PlaceResolver
 from typing import Optional, Literal
 import pandas as pd
 
 # instantiate a PlaceResolver object specific for countries
-_country_resolver = PlaceResolver(concordance_table="default",
-                                  custom_disambiguation="default",
-                                  dc_entity_type="Country")
+_country_resolver = PlaceResolver(
+    concordance_table="default",
+    custom_disambiguation="default",
+    dc_entity_type="Country",
+)
 
 _valid_sources = [
     "dcid",
@@ -24,14 +27,14 @@ _valid_sources = [
     "dac_code",
 ]
 
-_valid_targets = _valid_sources + ["region",
-                                   "region_code",
-                                   "subregion",
-                                   "subregion_code",
-                                   "intermediate_region_code",
-                                   "intermediate_region",
-                                   "income_level"
-
+_valid_targets = _valid_sources + [
+    "region",
+    "region_code",
+    "subregion",
+    "subregion_code",
+    "intermediate_region_code",
+    "intermediate_region",
+    "income_level",
 ]
 
 
@@ -39,9 +42,13 @@ def _get_list_from_bool(target_field, bool_field):
     """Helper function to get a list of countries from a boolean field."""
 
     if target_field not in _valid_sources:
-        raise ValueError(f"Invalid place format: {target_field}. Must be one of {_valid_sources}.")
+        raise ValueError(
+            f"Invalid place format: {target_field}. Must be one of {_valid_sources}."
+        )
 
-    countries = _country_resolver.get_concordance_dict(from_type=target_field, to_type=bool_field)
+    countries = _country_resolver.get_concordance_dict(
+        from_type=target_field, to_type=bool_field
+    )
 
     # filter only for value that are True
     countries = {k: v for k, v in countries.items() if v is True}
@@ -71,6 +78,7 @@ def get_un_members(place_format: Optional[str] = "dcid") -> list[str | int]:
 
     return _get_list_from_bool(place_format, "un_member")
 
+
 def get_un_observers(place_format: Optional[str] = "dcid") -> list[str | int]:
     """Get a list of UN observers in the specified format.
 
@@ -91,6 +99,7 @@ def get_un_observers(place_format: Optional[str] = "dcid") -> list[str | int]:
     """
 
     return _get_list_from_bool(place_format, "un_observer")
+
 
 def get_m49_places(place_format: Optional[str] = "dcid") -> list[str | int]:
     """Get a list of M49 countries and areas in the specified format.
@@ -135,6 +144,7 @@ def get_sids(place_format: Optional[str] = "dcid") -> list[str | int]:
 
     return _get_list_from_bool(place_format, "sids")
 
+
 def get_ldc(place_format: Optional[str] = "dcid") -> list[str | int]:
     """Get a list of Least Developed Countries (LDC) in the specified format.
 
@@ -155,6 +165,7 @@ def get_ldc(place_format: Optional[str] = "dcid") -> list[str | int]:
     """
 
     return _get_list_from_bool(place_format, "ldc")
+
 
 def get_lldc(place_format: Optional[str] = "dcid") -> list[str | int]:
     """Get a list of Landlocked Developing Countries (LLDC) in the specified format.
@@ -179,13 +190,13 @@ def get_lldc(place_format: Optional[str] = "dcid") -> list[str | int]:
 
 
 def resolve_places(
-            places: str | list[str] | pd.Series,
-            from_type: Optional[str] = None,
-            to_type: Optional[str] = "dcid",
-            not_found: Literal["raise", "ignore"] | str = "raise",
-            multiple_candidates: Literal["raise", "first", "ignore"] = "raise",
-            custom_mapping: Optional[dict] = None,
-            ):
+    places: str | list[str] | pd.Series,
+    from_type: Optional[str] = None,
+    to_type: Optional[str] = "dcid",
+    not_found: Literal["raise", "ignore"] | str = "raise",
+    multiple_candidates: Literal["raise", "first", "ignore"] = "raise",
+    custom_mapping: Optional[dict] = None,
+):
     """Resolve places
 
     Resolve places to a desired format. This function disambiguates places
@@ -248,7 +259,9 @@ def resolve_places(
 
     # check if the from_type is valid
     if from_type is not None and from_type not in _valid_sources:
-        raise ValueError(f"Invalid country format: {from_type}. Must be one of {_valid_sources}.")
+        raise ValueError(
+            f"Invalid country format: {from_type}. Must be one of {_valid_sources}."
+        )
 
     return _country_resolver.resolve(
         places=places,
@@ -259,13 +272,15 @@ def resolve_places(
         custom_mapping=custom_mapping,
     )
 
-def resolve_places_mapping(places: str | list[str] | pd.Series,
-                            to_type: Optional[str] = "dcid",
-                            from_type: Optional[str] = None,
-                            not_found: Literal["raise", "ignore"] | str = "raise",
-                            multiple_candidates: Literal["raise", "first", "ignore"] = "raise",
-                            custom_mapping: Optional[dict] = None,
-                            ) -> dict[str, str | int | None | list]:
+
+def resolve_places_mapping(
+    places: str | list[str] | pd.Series,
+    to_type: Optional[str] = "dcid",
+    from_type: Optional[str] = None,
+    not_found: Literal["raise", "ignore"] | str = "raise",
+    multiple_candidates: Literal["raise", "first", "ignore"] = "raise",
+    custom_mapping: Optional[dict] = None,
+) -> dict[str, str | int | None | list]:
     """Resolve places to a mapping dictionary of {place: resolved}
 
     Resolve places to a desired format. This function disambiguates places
@@ -328,7 +343,9 @@ def resolve_places_mapping(places: str | list[str] | pd.Series,
 
     # check if the from_type is valid
     if from_type is not None and from_type not in _valid_sources:
-        raise ValueError(f"Invalid country format: {from_type}. Must be one of {_valid_sources}.")
+        raise ValueError(
+            f"Invalid country format: {from_type}. Must be one of {_valid_sources}."
+        )
 
     return _country_resolver.resolve_map(
         places=places,
@@ -340,13 +357,14 @@ def resolve_places_mapping(places: str | list[str] | pd.Series,
     )
 
 
-def filter_places(places: list[str] | pd.Series,
-           filter_type: str,
-           filter_values: str | list[str],
-           from_type: Optional[str] = None,
-           not_found: Literal["raise", "ignore"] = "raise",
-           multiple_candidates: Literal["raise", "first"] = "raise",
-            ) -> pd.Series | list:
+def filter_places(
+    places: list[str] | pd.Series,
+    filter_type: str,
+    filter_values: str | list[str],
+    from_type: Optional[str] = None,
+    not_found: Literal["raise", "ignore"] = "raise",
+    multiple_candidates: Literal["raise", "first"] = "raise",
+) -> pd.Series | list:
     """Filter places
 
     Filter places based on a specific category like "region" for specific values like "Africa".
@@ -398,20 +416,32 @@ def filter_places(places: list[str] | pd.Series,
 
     # check if the filter_type is valid
     if filter_type not in _valid_targets:
-        raise ValueError(f"Invalid country format: {filter_type}. Must be one of {_valid_targets}.")
+        raise ValueError(
+            f"Invalid country format: {filter_type}. Must be one of {_valid_targets}."
+        )
 
     # check if the from_type is valid
     if from_type is not None and from_type not in _valid_sources:
-        raise ValueError(f"Invalid country format: {from_type}. Must be one of {_valid_sources}.")
+        raise ValueError(
+            f"Invalid country format: {from_type}. Must be one of {_valid_sources}."
+        )
 
     # check if the filter_values are valid - should exist in the concordance table
     if isinstance(filter_values, str):
         filter_values = [filter_values]
-    if not all([v in _country_resolver.concordance_table[filter_type].values for v in filter_values]):
+    if not all(
+        [
+            v in _country_resolver.concordance_table[filter_type].values
+            for v in filter_values
+        ]
+    ):
         # get a list of valid values, excluding any nulls
-        valid_values = list(_country_resolver.concordance_table[filter_type].dropna().unique())
-        raise ValueError(f"Invalid filter values: {filter_values}. Must be one of {valid_values}.")
-
+        valid_values = list(
+            _country_resolver.concordance_table[filter_type].dropna().unique()
+        )
+        raise ValueError(
+            f"Invalid filter values: {filter_values}. Must be one of {valid_values}."
+        )
 
     return _country_resolver.filter(
         places=places,
@@ -422,10 +452,13 @@ def filter_places(places: list[str] | pd.Series,
         multiple_candidates=multiple_candidates,
     )
 
-def filter_african_countries(places: str | list[str] | pd.Series,
-                             from_type: Optional[str] = None,
-                             not_found: Literal["raise", "ignore"] = "raise",
-                             multiple_candidates: Literal["raise", "first"] = "raise"):
+
+def filter_african_countries(
+    places: str | list[str] | pd.Series,
+    from_type: Optional[str] = None,
+    not_found: Literal["raise", "ignore"] = "raise",
+    multiple_candidates: Literal["raise", "first"] = "raise",
+):
     """Filter places for African countries
 
     Filter places based on the region "Africa". This function can disambiguate places
@@ -458,16 +491,19 @@ def filter_african_countries(places: str | list[str] | pd.Series,
                 - "first": use the first candidate.
                 - "ignore": keep the value as a list.
     """
-    return filter_places(places=places,
-                         filter_type="region",
-                         filter_values="Africa",
-                         from_type=from_type,
-                         not_found=not_found,
-                         multiple_candidates=multiple_candidates)
+    return filter_places(
+        places=places,
+        filter_type="region",
+        filter_values="Africa",
+        from_type=from_type,
+        not_found=not_found,
+        multiple_candidates=multiple_candidates,
+    )
 
 
-
-def get_places_by(by: str, filter_values: str | list[str], place_format: Optional[str] = "dcid") -> list[str | int]:
+def get_places_by(
+    by: str, filter_values: str | list[str], place_format: Optional[str] = "dcid"
+) -> list[str | int]:
     """Get places based on a specific category and values.
 
     This function can be used to get places based on a specific category like "region" for specific values like "Africa".
@@ -499,20 +535,28 @@ def get_places_by(by: str, filter_values: str | list[str], place_format: Optiona
 
     # check if the by is valid
     if by not in _valid_targets:
-        raise ValueError(f"Invalid country format: {by}. Must be one of {_valid_targets}.")
+        raise ValueError(
+            f"Invalid country format: {by}. Must be one of {_valid_targets}."
+        )
 
     if isinstance(filter_values, str):
         filter_values = [filter_values]
 
     # check if the filter_values are valid - should exist in the concordance table
-    if not all([v in _country_resolver.concordance_table[by].values for v in filter_values]):
+    if not all(
+        [v in _country_resolver.concordance_table[by].values for v in filter_values]
+    ):
         # get a list of valid values, excluding any nulls
         valid_values = list(_country_resolver.concordance_table[by].dropna().unique())
-        raise ValueError(f"Invalid filter values: {filter_values}. Must be one of {valid_values}.")
+        raise ValueError(
+            f"Invalid filter values: {filter_values}. Must be one of {valid_values}."
+        )
 
     # check if the place_format is valid
     if place_format not in _valid_sources:
-        raise ValueError(f"Invalid country format: {place_format}. Must be one of {_valid_sources}.")
+        raise ValueError(
+            f"Invalid country format: {place_format}. Must be one of {_valid_sources}."
+        )
 
     # filter the concordance table
     mapper = _country_resolver.get_concordance_dict(from_type=place_format, to_type=by)
@@ -539,4 +583,3 @@ def get_african_countries(place_format: Optional[str] = "dcid") -> list[str | in
     """
 
     return get_places_by("region", "Africa", place_format)
-

--- a/src/bblocks/places/resolver.py
+++ b/src/bblocks/places/resolver.py
@@ -788,9 +788,7 @@ class PlaceResolver:
             return [place for place in places if place in filtered_places]
 
         # if the places is a pd.Series map the filtered places to the original places
-        return pd.Series(
-            [place for place in places if place in filtered_places]
-        )
+        return pd.Series([place for place in places if place in filtered_places])
 
     def get_concordance_dict(
         self, from_type: str, to_type: str, include_nulls: bool = False


### PR DESCRIPTION
This pull request enhances the `bblocks.places` module by improving imports, refining error handling, and fixing logic in the `resolver` class. The most significant changes include updating imports in `__init__.py`, modifying error handling for missing concordance tables, and refining the `filter` method for better handling of `pd.Series`.

### Imports and module organization:
* [`src/bblocks/places/__init__.py`](diffhunk://#diff-a1b48212d0abef06af2cc8389c579a8b973cb812b776c50e4e5617e17c271a57R2-R20): Added imports for `PlaceResolver` and various utility functions to streamline access to key functionalities in the `bblocks.places` module.

### Error handling improvements:
* `src/bblocks/places/resolver.py`:
  - Updated `resolve` method to allow custom strings for the `not_found` parameter, enhancing flexibility in handling unresolved places.
  - Replaced checks for falsy values with explicit `None` checks in `concordance_table` and `get_concordance_dict` methods to improve clarity and avoid potential issues with empty data structures. [[1]](diffhunk://#diff-a0bda6c939cf9b10c5106a5dfdd58b4d8f65685171190df475bc753a32f4df59L692-R692) [[2]](diffhunk://#diff-a0bda6c939cf9b10c5106a5dfdd58b4d8f65685171190df475bc753a32f4df59L808-R810)

### Logic and functionality fixes:
* [`src/bblocks/places/resolver.py`](diffhunk://#diff-a0bda6c939cf9b10c5106a5dfdd58b4d8f65685171190df475bc753a32f4df59R789-R792): Adjusted the `filter` method to handle `pd.Series` more effectively by mapping filtered places back to their original indices, ensuring consistent output formats.