### PR TITLE
Add unit tests with mocking

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+# Stub pandas module with minimal functionality
+pd_stub = types.ModuleType('pandas')
+class Series(list):
+    def map(self, func):
+        return Series([func(x) for x in self])
+    def unique(self):
+        seen = []
+        for x in self:
+            if x not in seen:
+                seen.append(x)
+        return seen
+pd_stub.Series = Series
+pd_stub.DataFrame = type('DataFrame', (), {})
+pd_stub.read_csv = lambda *a, **k: pd_stub.DataFrame()
+sys.modules['pandas'] = pd_stub
+
+# Dummy Data Commons client implementation
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+    def to_flat_dict(self):
+        return self._data
+    def get_properties(self):
+        return self._data
+
+class DummyResolve:
+    def __init__(self):
+        self.mapping = {}
+    def fetch_dcids_by_name(self, entities, entity_type):
+        if isinstance(entities, str):
+            entities = [entities]
+        return DummyResponse({e: self.mapping.get(e) for e in entities})
+
+class DummyNode:
+    def __init__(self):
+        self.mapping = {}
+    def fetch_property_values(self, dcids, prop):
+        return DummyResponse({d: self.mapping.get(d) for d in dcids})
+
+class DummyClient:
+    def __init__(self, **kwargs):
+        self.resolve = DummyResolve()
+        self.node = DummyNode()
+
+dc_stub = types.ModuleType('datacommons_client')
+dc_stub.DataCommonsClient = DummyClient
+sys.modules['datacommons_client'] = dc_stub
+
+# Load package modules without executing original __init__
+PACKAGE_ROOT = Path(__file__).resolve().parents[1] / 'src' / 'bblocks' / 'places'
+
+bblocks_pkg = types.ModuleType('bblocks')
+bblocks_pkg.__path__ = [str(PACKAGE_ROOT.parent)]
+sys.modules['bblocks'] = bblocks_pkg
+places_pkg = types.ModuleType('bblocks.places')
+places_pkg.__path__ = [str(PACKAGE_ROOT)]
+sys.modules['bblocks.places'] = places_pkg
+
+for name in ['config', 'utils', 'concordance', 'disambiguator', 'resolver']:
+    spec = importlib.util.spec_from_file_location(f'bblocks.places.{name}', PACKAGE_ROOT / f'{name}.py')
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f'bblocks.places.{name}'] = module
+    spec.loader.exec_module(module)
+
+# expose helpers
+pytest_plugins = []

--- a/tests/test_disambiguator.py
+++ b/tests/test_disambiguator.py
@@ -1,0 +1,35 @@
+from bblocks.places.disambiguator import (
+    custom_disambiguation,
+    fetch_dcids_by_name,
+    resolve_places_to_dcids,
+)
+from bblocks.places.resolver import PlaceResolver
+from datacommons_client import DataCommonsClient
+
+
+def test_custom_disambiguation():
+    mapping = {"Congo": "country/COG"}
+    assert custom_disambiguation("Congo", mapping) == "country/COG"
+    assert custom_disambiguation("congo", mapping) == "country/COG"
+    assert custom_disambiguation("Unknown", mapping) is None
+
+
+def test_fetch_dcids_by_name_chunked():
+    client = DataCommonsClient()
+    client.resolve.mapping = {"Zimbabwe": "country/ZWE", "Italy": "country/ITA"}
+    result = fetch_dcids_by_name(client, ["Zimbabwe", "Italy"], "Country", chunk_size=1)
+    assert result == {"Zimbabwe": "country/ZWE", "Italy": "country/ITA"}
+
+
+def test_resolve_places_to_dcids(monkeypatch):
+    client = DataCommonsClient()
+    client.resolve.mapping = {"Italy": "country/ITA", "Kenya": None}
+    disamb = {"Congo": "country/COG"}
+    result = resolve_places_to_dcids(
+        client, ["Italy", "Congo", "Kenya"], "Country", disambiguation_dict=disamb
+    )
+    assert result == {
+        "Italy": "country/ITA",
+        "Congo": "country/COG",
+        "Kenya": None,
+    }

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,73 @@
+import types
+import pytest
+
+import bblocks.places.resolver as resolver
+from bblocks.places.resolver import PlaceResolver, handle_not_founds, handle_multiple_candidates
+
+
+def make_resolver(columns=None):
+    res = PlaceResolver(concordance_table=None)
+    if columns is not None:
+        res._concordance_table = types.SimpleNamespace(columns=columns)
+    return res
+
+
+def test_handle_not_founds_raise():
+    with pytest.raises(resolver.PlaceNotFoundError):
+        handle_not_founds({"A": None}, not_found="raise")
+
+
+def test_handle_not_founds_ignore():
+    result = handle_not_founds({"A": None}, not_found="ignore")
+    assert result == {"A": None}
+
+
+def test_handle_not_founds_custom():
+    result = handle_not_founds({"A": None}, not_found="missing")
+    assert result == {"A": "missing"}
+
+
+def test_handle_multiple_candidates_raise():
+    with pytest.raises(resolver.MultipleCandidatesError):
+        handle_multiple_candidates({"A": [1, 2]}, multiple_candidates="raise")
+
+
+def test_handle_multiple_candidates_first():
+    result = handle_multiple_candidates({"A": ["x", "y"]}, multiple_candidates="first")
+    assert result["A"] == "x"
+
+
+def test_handle_multiple_candidates_ignore():
+    result = handle_multiple_candidates({"A": ["x", "y"]}, multiple_candidates="ignore")
+    assert result["A"] == ["x", "y"]
+
+
+def test_map_candidates_to_dc_property():
+    res = make_resolver()
+    res._dc_client.node.mapping = {"id1": "p1", "id2": "p2", "id3": None}
+    candidates = {"A": "id1", "B": ["id2", "id3"], "C": None}
+    result = res._map_candidates_to_dc_property(candidates, "prop")
+    assert result == {"A": "p1", "B": "p2", "C": None}
+
+
+def test_resolve_with_disambiguation_paths(monkeypatch):
+    res = make_resolver(columns=["iso"])
+    monkeypatch.setattr(resolver, "resolve_places_to_dcids", lambda **k: {"A": "id1"})
+    monkeypatch.setattr(resolver, "map_candidates", lambda **k: {"A": "mapped"})
+    monkeypatch.setattr(resolver.PlaceResolver, "_map_candidates_to_dc_property", lambda self, c, d: {"A": "prop"})
+
+    assert res._resolve_with_disambiguation("dcid", ["A"]) == {"A": "id1"}
+    assert res._resolve_with_disambiguation("iso", ["A"]) == {"A": "mapped"}
+    res._concordance_table = types.SimpleNamespace(columns=[])
+    assert res._resolve_with_disambiguation("prop", ["A"]) == {"A": "prop"}
+
+
+def test_resolve_without_disambiguation_paths(monkeypatch):
+    res = make_resolver(columns=["iso"])
+    monkeypatch.setattr(resolver, "map_places", lambda **k: {p: f"{k['to_type']}_{p}" for p in k['places']})
+    monkeypatch.setattr(resolver.PlaceResolver, "_map_candidates_to_dc_property", lambda self, c, d: {k: f"prop_{v}" for k, v in c.items()})
+
+    assert res._resolve_without_disambiguation(["A"], "dcid", "iso") == {"A": "iso_A"}
+    res._concordance_table = types.SimpleNamespace(columns=[])
+    assert res._resolve_without_disambiguation(["A"], "name", "prop") == {"A": "prop_dcid_A"}
+    assert res._resolve_without_disambiguation(["A"], "dcid", "prop") == {"A": "prop_A"}


### PR DESCRIPTION
## Summary
- add pytest conftest to stub dependencies and load modules
- test disambiguation helpers
- test resolver helper logic

## Testing
- `pytest -q` *(fails: command not found)*