### PR TITLE
Fix logger warning usage

### DIFF
--- a/src/bblocks/places/resolver.py
+++ b/src/bblocks/places/resolver.py
@@ -51,7 +51,7 @@ def handle_not_founds(
             if not_found == "raise":
                 raise PlaceNotFoundError(f"Place not found: {place}")
             elif not_found == "ignore":
-                logger.warn(f"Place not found: {place}")
+                logger.warning(f"Place not found: {place}")
                 continue
             else:
                 # set the value of the candidate to the not_found value
@@ -97,7 +97,7 @@ def handle_multiple_candidates(
                 )
             elif multiple_candidates == "ignore":
                 # keep the value of the candidate as a list
-                logger.warn(
+                logger.warning(
                     f"Multiple candidates found for {place}. Keeping all candidates: {cands}"
                 )
 


### PR DESCRIPTION
## Summary
- replace deprecated `logger.warn` usage with `logger.warning`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bblocks')*
- `pip install -e .` *(fails: could not find poetry-core due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_684941128ef4832daf4ad2b551c22bbf