### PR TITLE
Package concordance CSV and load via importlib.resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 [tool.poetry]
 packages = [{include = "bblocks/places", from = "src"}]
 
+[[tool.poetry.include]]
+path = "src/bblocks/places/concordance.csv"
+
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"

--- a/src/bblocks/places/resolver.py
+++ b/src/bblocks/places/resolver.py
@@ -8,6 +8,8 @@ from datacommons_client import DataCommonsClient
 from typing import Optional, Literal
 import pandas as pd
 
+from importlib import resources
+
 from bblocks.places.disambiguator import resolve_places_to_dcids
 from bblocks.places.concordance import (
     map_candidates,
@@ -137,7 +139,8 @@ def read_default_concordance_table() -> pd.DataFrame:
     }
 
     return pd.read_csv(
-        Paths.project / "places" / "concordance.csv", dtype=concordance_dtypes
+        resources.files("bblocks.places").joinpath("concordance.csv"),
+        dtype=concordance_dtypes,
     )
 
 


### PR DESCRIPTION
## Summary
- ship `concordance.csv` with the wheel using `tool.poetry.include`
- load the default concordance table via `importlib.resources`

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'datacommons_client')*

------
https://chatgpt.com/codex/tasks/task_b_684941f7ec04832dbb07006265a6bd3f