### PR TITLE
Fix list deduplication preserving order

### DIFF
--- a/src/bblocks/places/resolver.py
+++ b/src/bblocks/places/resolver.py
@@ -606,7 +606,8 @@ class PlaceResolver:
             places = [places]
 
         elif isinstance(places, list):
-            places = list(set(places))  # deduplicate
+            # deduplicate while preserving order
+            places = list(dict.fromkeys(places))
 
         elif isinstance(places, pd.Series):
             places = list(places.unique())
@@ -768,7 +769,8 @@ class PlaceResolver:
 
         # if the places is a list ensure it is unique
         if isinstance(places, list):
-            places_to_filter = list(set(places))
+            # deduplicate while preserving order
+            places_to_filter = list(dict.fromkeys(places))
         # convert places to a list if it is a pd.Series
         elif isinstance(places, pd.Series):
             places_to_filter = list(places.unique())


### PR DESCRIPTION
## Summary
- ensure `resolve_map` and `filter` keep input order when deduplicating lists

## Testing
- `PYTHONPATH=./src pytest -q` *(fails: ModuleNotFoundError: No module named 'datacommons_client')*

------
https://chatgpt.com/codex/tasks/task_b_68494351869c832d93bb4817d1854371