### PR TITLE
Fix allowed values for filtering functions

### DIFF
--- a/src/bblocks/places/main.py
+++ b/src/bblocks/places/main.py
@@ -465,7 +465,7 @@ def filter_places(
     filter_values: str | list[str],
     from_type: Optional[str] = None,
     not_found: Literal["raise", "ignore"] = "raise",
-    multiple_candidates: Literal["raise", "first", "last"] = "raise",
+    multiple_candidates: Literal["raise", "first", "last", "ignore"] = "raise",
 ) -> pd.Series | list:
     """Filter places
 
@@ -544,7 +544,7 @@ def filter_african_countries(
     places: str | list[str] | pd.Series,
     from_type: Optional[str] = None,
     not_found: Literal["raise", "ignore"] = "raise",
-    multiple_candidates: Literal["raise", "first", "last"] = "raise",
+    multiple_candidates: Literal["raise", "first", "last", "ignore"] = "raise",
 ):
     """Filter places for African countries
 

--- a/src/bblocks/places/resolver.py
+++ b/src/bblocks/places/resolver.py
@@ -673,6 +673,7 @@ class PlaceResolver:
                 Default is "raise". Options are:
                     - "raise": raise an error.
                     - "first": use the first candidate.
+                    - "last": use the last candidate.
                     - "ignore": keep the value as a list.
 
             custom_mapping: A dictionary of custom mappings to use. If this is provided, it will
@@ -742,7 +743,7 @@ class PlaceResolver:
         filter_values: str | list[str],
         from_type: Optional[str] = None,
         not_found: Literal["raise", "ignore"] = "raise",
-        multiple_candidates: Literal["raise", "first", "last"] = "raise",
+        multiple_candidates: Literal["raise", "first", "last", "ignore"] = "raise",
     ) -> list[str] | pd.Series:
         """Filter places
 
@@ -767,6 +768,8 @@ class PlaceResolver:
                 Default is "raise". Options are:
                     - "raise": raise an error.
                     - "first": use the first candidate.
+                    - "last": use the last candidate.
+                    - "ignore": keep the value as a list.
 
         Returns:
             The filtered places


### PR DESCRIPTION
## Summary
- allow "ignore" as a valid choice for `multiple_candidates` in filtering helpers
- document the new option in `PlaceResolver.filter`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bblocks')*

------
https://chatgpt.com/codex/tasks/task_b_68494b66afe4832d92662da9fd7db722