### PR TITLE
Add multiple-category filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ but the package offers more flexibility (jump to the customization section)
 
 Resolve a list of ambiguous countries
 ```python
-countries = ["Zimbabwe", "Italy", "Botswana", "United States"]
+countries = ["Zimbabwe", "Italy", "Botswana", "United States", "Seychelles"]
 resolved_countries = places.resolve(countries)
 print(resolved_countries)
 # Output:
@@ -212,13 +212,22 @@ print(resolved_countries)
 You can filter places based on some categories like regions or income levels.
 
 ```python
-countries = ["Zimbabwe", "Italy", "Botswana", "United States"]
+countries = ["Zimbabwe", "Italy", "Botswana", "United States", "Seychelles"]
 
 # Let's say we have a list of countries and we want to filter them for high income countries
 filtered_countries = places.filter_places(countries, "income_level", "High income")
 print(filtered_countries)
 # Output:
 # ['Italy', 'United States']
+
+# You can also filter using multiple categories at once
+high_income_africa = places.filter_places_multiple(
+    countries,
+    filters={"region": "Africa", "income_level": "High income"},
+)
+print(high_income_africa)
+# Output:
+# ['Seychelles']
 ```
 
 Helper functions for specific filtering exists, for example to filter for African countries

--- a/src/bblocks/places/__init__.py
+++ b/src/bblocks/places/__init__.py
@@ -15,6 +15,7 @@ from bblocks.places.main import (
     filter_places,
     resolve_map,
     filter_african_countries,
+    filter_places_multiple,
     # Category-based filters
     get_places_by,
     get_places_by_multiple,

--- a/src/tests/test_filters.py
+++ b/src/tests/test_filters.py
@@ -1,0 +1,20 @@
+import pytest
+
+from bblocks.places.main import filter_places_multiple
+
+
+def test_filter_places_multiple():
+    countries = [
+        "Zimbabwe",
+        "Italy",
+        "Botswana",
+        "United States",
+        "Seychelles",
+    ]
+
+    filtered = filter_places_multiple(
+        countries,
+        filters={"region": "Africa", "income_level": "High income"},
+    )
+
+    assert filtered == ["Seychelles"]


### PR DESCRIPTION
## Summary
- add `filter_places_multiple` to filter a list of places with several categories
- export the helper
- document multi-category filtering in README
- test the new function

## Testing
- `PYTHONPATH=src pytest -q` *(fails: No module named 'datacommons_client')*

------
https://chatgpt.com/codex/tasks/task_b_68493fe88040832dbfc57b0baae26bc8