### PR TITLE
Fix resolution with null inputs

### DIFF
--- a/src/bblocks/places/main.py
+++ b/src/bblocks/places/main.py
@@ -182,7 +182,9 @@ def get_un_observers(
         ValueError: If ``raise_if_empty`` is ``True`` and no countries are found.
     """
 
-    return _get_list_from_bool(place_format, "un_observer", raise_if_empty=raise_if_empty)
+    return _get_list_from_bool(
+        place_format, "un_observer", raise_if_empty=raise_if_empty
+    )
 
 
 def get_m49_places(
@@ -209,7 +211,9 @@ def get_m49_places(
         ValueError: If ``raise_if_empty`` is ``True`` and no countries are found.
     """
 
-    return _get_list_from_bool(place_format, "m49_member", raise_if_empty=raise_if_empty)
+    return _get_list_from_bool(
+        place_format, "m49_member", raise_if_empty=raise_if_empty
+    )
 
 
 def get_sids(
@@ -300,6 +304,8 @@ def resolve(
     not_found: Literal["raise", "ignore"] | str = "raise",
     multiple_candidates: Literal["raise", "first", "last", "ignore"] = "raise",
     custom_mapping: Optional[dict] = None,
+    *,
+    ignore_nulls: bool = True,
 ):
     """Resolve places
 
@@ -358,6 +364,9 @@ def resolve(
             override any other mappings. Disambiguation and concordance will not be run for those places.
             The keys are the original places and the values are the resolved places.
 
+        ignore_nulls: If ``True`` null values are ignored during resolution and left as ``None``.
+            A warning is logged for ignored values. If ``False`` and nulls are present, a ``ValueError`` is raised.
+
     Returns:
         Resolved places
     """
@@ -373,6 +382,7 @@ def resolve(
         not_found=not_found,
         multiple_candidates=multiple_candidates,
         custom_mapping=custom_mapping,
+        ignore_nulls=ignore_nulls,
     )
 
 
@@ -383,6 +393,8 @@ def resolve_map(
     not_found: Literal["raise", "ignore"] | str = "raise",
     multiple_candidates: Literal["raise", "first", "last", "ignore"] = "raise",
     custom_mapping: Optional[dict] = None,
+    *,
+    ignore_nulls: bool = True,
 ) -> dict[str, str | int | None | list]:
     """Resolve places to a mapping dictionary of {place: resolved}
 
@@ -441,6 +453,9 @@ def resolve_map(
             override any other mappings. Disambiguation and concordance will not be run for those places.
             The keys are the original places and the values are the resolved places.
 
+        ignore_nulls: If ``True`` null values are ignored during resolution and left as ``None``.
+            A warning is logged for ignored values. If ``False`` and nulls are present, a ``ValueError`` is raised.
+
     Returns:
         A dictionary mapping the places to the desired format.
     """
@@ -456,6 +471,7 @@ def resolve_map(
         not_found=not_found,
         multiple_candidates=multiple_candidates,
         custom_mapping=custom_mapping,
+        ignore_nulls=ignore_nulls,
     )
 
 
@@ -612,8 +628,6 @@ def filter_african_countries(
     )
 
 
-
-
 def get_places(
     filters: dict[str, str | list[str | int | bool]],
     place_format: str = "dcid",
@@ -675,9 +689,7 @@ def get_places(
 
     query = " and ".join([f"{k} in {v}" for k, v in filters.items()])
     result = list(
-        _country_resolver.concordance_table.query(query)[place_format]
-        .dropna()
-        .unique()
+        _country_resolver.concordance_table.query(query)[place_format].dropna().unique()
     )
 
     if not result:

--- a/src/tests/test_nulls.py
+++ b/src/tests/test_nulls.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import pytest
+
+from bblocks.places.main import resolve, resolve_map
+
+
+def test_resolve_ignores_nulls_series():
+    data = pd.Series(["ITA", pd.NA, "AFG"])
+    result = resolve(data, from_type="iso3_code", to_type="iso2_code")
+    assert list(result) == ["IT", pd.NA, "AF"]
+
+
+def test_resolve_raises_on_nulls_when_disabled():
+    data = pd.Series(["ITA", pd.NA])
+    with pytest.raises(ValueError):
+        resolve(data, from_type="iso3_code", to_type="iso2_code", ignore_nulls=False)
+
+
+def test_resolve_map_ignores_nulls():
+    mapping = resolve_map(["ITA", None], from_type="iso3_code", to_type="iso2_code")
+    assert mapping == {"ITA": "IT"}


### PR DESCRIPTION
## Summary
- handle null input values in `PlaceResolver.resolve_map` and `resolve`
- expose `ignore_nulls` parameter through public API
- add regression tests

## Testing
- `black src/bblocks/places/resolver.py src/bblocks/places/main.py src/tests/test_nulls.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684bf243f8f8832da310cea85eb6a6e9