### PR TITLE
70 resolver tests

### DIFF
--- a/src/bblocks/places/resolver.py
+++ b/src/bblocks/places/resolver.py
@@ -19,10 +19,35 @@ from bblocks.places.concordance import (
 )
 from bblocks.places.config import (
     logger,
-    Paths,
     PlaceNotFoundError,
     MultipleCandidatesError,
 )
+
+# Default concordance table dtypes
+DEFAULT_CONCORDANCE_DTYPES: dict= {
+        "dcid": "string",
+        "name_official": "string",
+        "name_short": "string",
+        "iso2_code": "string",
+        "iso3_code": "string",
+        "iso_numeric_code": "Int64",  # Nullable integer
+        "m49_code": "Int64",
+        "region_code": "Int64",
+        "region": "string",
+        "subregion_code": "Int64",
+        "subregion": "string",
+        "m49_member": "boolean",
+        "intermediate_region_code": "Int64",
+        "intermediate_region": "string",
+        "ldc": "boolean",
+        "lldc": "boolean",
+        "sids": "boolean",
+        "un_member": "boolean",
+        "un_observer": "boolean",
+        "un_former_member": "boolean",
+        "dac_code": "Int64",
+        "income_level": "string",
+    }
 
 
 def handle_not_founds(
@@ -35,9 +60,9 @@ def handle_not_founds(
         candidates: A dict of candidates.
         not_found: How to handle not founds.
             Options are:
-                - "raise": raise an error.
-                - "ignore": keep the value as None.
-                - Any other string to set as the value for not found places.
+            - `raise`: raise an error.
+            - `ignore`: keep the value as None.
+            - Any other string to set as the value for not found places.
 
     Returns:
         The candidates with not found places handled
@@ -146,34 +171,8 @@ def handle_missing_values(
 def read_default_concordance_table() -> pd.DataFrame:
     """Read the default concordance table"""
 
-    concordance_dtypes = {
-        "dcid": "string",
-        "name_official": "string",
-        "name_short": "string",
-        "iso2_code": "string",
-        "iso3_code": "string",
-        "iso_numeric_code": "Int64",  # Nullable integer
-        "m49_code": "Int64",
-        "region_code": "Int64",
-        "region": "string",
-        "subregion_code": "Int64",
-        "subregion": "string",
-        "intermediate_region_code": "Int64",
-        "intermediate_region": "string",
-        "ldc": "boolean",
-        "lldc": "boolean",
-        "sids": "boolean",
-        "un_member": "boolean",
-        "un_observer": "boolean",
-        "un_former_member": "boolean",
-        "dac_code": "Int64",
-        "income_level": "string",
-    }
-
-    return pd.read_csv(
-        resources.files("bblocks.places").joinpath("concordance.csv"),
-        dtype=concordance_dtypes,
-    )
+    path = resources.files("bblocks.places").joinpath("concordance.csv")
+    return pd.read_csv(path, dtype=DEFAULT_CONCORDANCE_DTYPES)
 
 
 class PlaceResolver:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,5 @@
+"""Tests for the resolver module."""
+
+import pytest
+
+from bblocks.places import resolver

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -3,3 +3,107 @@
 import pytest
 
 from bblocks.places import resolver
+from bblocks.places.config import PlaceNotFoundError, MultipleCandidatesError
+
+# ----------------------------------------
+# Tests for the handle_not_founds function
+# ----------------------------------------
+
+def test_handle_not_founds_raises_when_none_and_raise():
+    """Raises if a candidate is None and not_found='raise'."""
+    candidates = {"A": None, "B": "value"}
+    with pytest.raises(PlaceNotFoundError):
+        resolver.handle_not_founds(candidates, not_found="raise")
+
+
+def test_handle_not_founds_ignore_keeps_none():
+    """Keeps None values when not_found='ignore'."""
+    candidates = {"A": None, "B": "value"}
+    result = resolver.handle_not_founds(candidates.copy(), not_found="ignore")
+    assert result == {"A": None, "B": "value"}
+
+
+def test_handle_not_founds_replaces_none_with_custom_string():
+    """Replaces None values with the provided not_found string."""
+    candidates = {"A": None, "B": "value"}
+    result = resolver.handle_not_founds(candidates.copy(), not_found="MISSING")
+    assert result == {"A": "MISSING", "B": "value"}
+
+
+# ----------------------------------------
+# Tests for the handle_multiple_candidates function
+# ----------------------------------------
+
+def test_handle_multiple_candidates_raise_error_on_list():
+    """Raises when multiple_candidates='raise' and a candidate is a list."""
+    candidates = {"A": ["x","y"], "B": "single"}
+    with pytest.raises(MultipleCandidatesError):
+        resolver.handle_multiple_candidates(candidates, multiple_candidates="raise")
+
+def test_handle_multiple_candidates_first_picks_first():
+    """Selects the first element when multiple_candidates='first'."""
+    candidates = {"A": ["x","y"], "B": ["u","v"], "C": "only"}
+    result = resolver.handle_multiple_candidates(candidates.copy(), multiple_candidates="first")
+    assert result == {"A": "x", "B": "u", "C": "only"}
+
+def test_handle_multiple_candidates_last_picks_last():
+    """Selects the last element when multiple_candidates='last'."""
+    candidates = {"A": ["x","y"], "B": ["u","v"], "C": "only"}
+    result = resolver.handle_multiple_candidates(candidates.copy(), multiple_candidates="last")
+    assert result == {"A": "y", "B": "v", "C": "only"}
+
+def test_handle_multiple_candidates_ignore_keeps_lists():
+    """Keeps list values when multiple_candidates='ignore'."""
+    candidates = {"A": ["x","y"], "B": ["u"], "C": "only"}
+    result = resolver.handle_multiple_candidates(candidates.copy(), multiple_candidates="ignore")
+    assert result == {"A": ["x","y"], "B": ["u"], "C": "only"}
+
+def test_handle_multiple_candidates_invalid_option_raises_value_error():
+    """Raises ValueError for an unsupported multiple_candidates option."""
+    candidates = {"A": ["x","y"], "B": "single"}
+    with pytest.raises(ValueError):
+        resolver.handle_multiple_candidates(candidates, multiple_candidates="unsupported")
+
+# ----------------------------------------
+# Tests for the handle_missing_values function
+# ----------------------------------------
+
+def test_handle_missing_values_logs_warning_for_none_values(caplog):
+    """Warns when a candidate is None but dcid_map has a non-null value."""
+    candidates = {"A": None, "B": None}
+    dcid_map = {"A": "dcidA", "B": None}
+    caplog.set_level("WARNING")
+    result = resolver.handle_missing_values(candidates.copy(), dcid_map, to_type="test")
+    assert "No value found for 'A' when mapping to 'test'" in caplog.text
+    # candidates dict should remain unchanged
+    assert result == {"A": None, "B": None}
+
+def test_handle_missing_values_no_warning_when_dcid_missing(caplog):
+    """No warning if dcid_map entry is None, even when candidate is None."""
+    candidates = {"A": None}
+    dcid_map = {"A": None}
+    caplog.set_level("WARNING")
+    result = resolver.handle_missing_values(candidates.copy(), dcid_map, to_type="foo")
+    assert caplog.text == ""
+    assert result == {"A": None}
+
+def test_handle_missing_values_no_warning_for_non_none_values(caplog):
+    """No warning when candidate value is present."""
+    candidates = {"A": "value"}
+    dcid_map = {"A": "dcidA"}
+    caplog.set_level("WARNING")
+    result = resolver.handle_missing_values(candidates.copy(), dcid_map, to_type="bar")
+    assert caplog.text == ""
+    assert result == {"A": "value"}
+
+
+# ----------------------------------------
+# Tests for the read_default_concordance_table function
+# ----------------------------------------
+
+def test_read_default_concordance_table_has_exact_columns():
+    """Ensure DataFrame columns exactly match DEFAULT_CONCORDANCE_DTYPES keys."""
+    df = resolver.read_default_concordance_table()
+    expected = set(resolver.DEFAULT_CONCORDANCE_DTYPES.keys())
+    assert set(df.columns) == expected, f"Got columns: {df.columns.tolist()}"
+    assert len(df.columns) == len(expected)


### PR DESCRIPTION
This pull request refactors the `src/bblocks/places/resolver.py` file to improve code maintainability and readability. The most significant changes include introducing a global constant for default concordance table dtypes, updating related functions to use this constant, and improving documentation formatting.

### Refactoring for maintainability:

* Introduced a global constant `DEFAULT_CONCORDANCE_DTYPES` to define default concordance table dtypes, replacing inline definitions in the `read_default_concordance_table` function. This ensures consistency and simplifies updates to dtype definitions.

* Updated the `read_default_concordance_table` function to use the new `DEFAULT_CONCORDANCE_DTYPES` constant, reducing redundancy and improving code clarity.

### Documentation improvements:

* Improved formatting of the `not_found` parameter documentation in the `handle_not_founds` function by using backticks for options, enhancing readability and consistency with Python docstring conventions.