### PR TITLE
chore!: deprecate bblocks-places in favour of resolvekit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+> **Deprecated.** `bblocks-places` is no longer maintained. `0.0.6` is the final release.
+> Please migrate to [resolvekit](https://pypi.org/project/resolvekit/), which covers the
+> same place-resolution functionality and is under active development.
+
 # bblocks-places
 
-__Resolve and standardize places and work with political and geographic groupings__
+**Resolve and standardize places and work with political and geographic groupings**
 
 [![PyPI](https://img.shields.io/pypi/v/bblocks_places.svg)](https://pypi.org/project/bblocks_places/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/bblocks_places.svg)](https://pypi.org/project/bblocks_places/)
@@ -8,26 +12,24 @@ __Resolve and standardize places and work with political and geographic grouping
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![codecov](https://codecov.io/gh/ONEcampaign/bblocks-places/graph/badge.svg?token=3ONEA8JQTC)](https://codecov.io/gh/ONEcampaign/bblocks-places)
 
-
-Working with country data can be tedious. One source calls it “South Korea” another says 
-“Republic of Korea” a third uses “KOR” — and suddenly your analysis breaks and you spend hours 
-manually standardizing all the names. These inconsistencies are common in cross-geographic datasets 
+Working with country data can be tedious. One source calls it “South Korea” another says
+“Republic of Korea” a third uses “KOR” — and suddenly your analysis breaks and you spend hours
+manually standardizing all the names. These inconsistencies are common in cross-geographic datasets
 and can lead to data cleaning headaches, merge errors, or misleading conclusions.
 
-bblocks-places eliminates this hassle by offering a simple, reliable interface to resolve, 
+bblocks-places eliminates this hassle by offering a simple, reliable interface to resolve,
 standardize, and work with country, region, and other place names.
 
-__Key features__:
+**Key features**:
 
 - Disambiguate and standardize free-text country names (e.g. "Ivory Coast" → “Côte d’Ivoire”)
 - Convert between place formats like ISO codes and official names
 - Filter and retrieve countries by attributes like region, income group, or UN membership
-- Customize resolution logic with your own concordance or override mappings 
-
+- Customize resolution logic with your own concordance or override mappings
 
 Built on top of Google's [Data Commons](https://datacommons.org/), an open knowledge graph integrating public data from the
-UN, World Bank, and more. `bblocks-places` is part of the bblocks ecosystem, 
-a set of Python packages designed as building blocks for working with data in the international development 
+UN, World Bank, and more. `bblocks-places` is part of the bblocks ecosystem,
+a set of Python packages designed as building blocks for working with data in the international development
 and humanitarian sectors.
 
 Read the [documentation](https://docs.one.org/tools/bblocks/places/)
@@ -35,7 +37,7 @@ for more details on how to use the package and the motivation for its creation.
 
 ## Installation
 
-The package can be installed in various ways. 
+The package can be installed in various ways.
 
 ```bash
 pip install bblocks-places
@@ -106,13 +108,13 @@ print(african_countries)
 
 #### Get places
 
-We don't always want to resolve or standardize places. Sometimes we simple want to know what places belong to a 
+We don't always want to resolve or standardize places. Sometimes we simple want to know what places belong to a
 particular category. For example we might want to know what countries in Africa are classified as upper income
 
 ```python
-ui_africa = places.get_places(filters={"region": "Africa", 
-                                       "income_level": ["Upper middle income", 
-                                                        "High income"]}, 
+ui_africa = places.get_places(filters={"region": "Africa",
+                                       "income_level": ["Upper middle income",
+                                                        "High income"]},
                               place_format="name_short"
                               )
 
@@ -125,6 +127,7 @@ print(ui_africa)
 Visit the [documentation page](https://docs.one.org/tools/bblocks/places/) for the full package documentation and examples.
 
 ## Contributing
+
 Contributions are welcome! Please see the
-[CONTRIBUTING](https://github.com/ONEcampaign/bblocks-places/blob/main/CONTRIBUTING.md) 
+[CONTRIBUTING](https://github.com/ONEcampaign/bblocks-places/blob/main/CONTRIBUTING.md)
 page for details on how to get started, report bugs, fix issues, and submit enhancements.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,26 +1,38 @@
 # Changelog
 
 ## v1.0.0 (in development)
+
 - Stable release of the `bblocks-places` package
 
 ## v0.1.0 (in development)
+
 - Initial minor release of the `bblocks-places` package for external testing
 
+## v0.0.6 (2026-08-13)
+
+- Deprecated the package in favour of [resolvekit](https://pypi.org/project/resolvekit/). This is the final release; `bblocks-places` will not receive further updates.
+- Importing the package now raises a `DeprecationWarning` pointing to `resolvekit`.
+
 ## v0.0.5 (2026-02-09)
-- Bug fix: resolving from known numeric entity type 
+
+- Bug fix: resolving from known numeric entity type
 - Added additional DAC codes to the concordance table
 
 ## v0.0.4 (2025-09-24)
+
 - Updated concordance table income groupings
 
 ## v0.0.3 (2025-06-23)
+
 - Bug fixes for handling of not found places
 - Fix requests dependency
-- Bug fix DCStatusError 500 - handle cases where an entity input is not valid 
-for the resolve endpoint.
+- Bug fix DCStatusError 500 - handle cases where an entity input is not valid
+  for the resolve endpoint.
 
 ## v0.0.2 (2025-06-18)
+
 - Set up GitHub Actions for CI/CD PYPI deployment
 
 ## v0.0.1 (2025-06-18)
+
 - Test release to PyPI

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,28 +1,30 @@
+> **Deprecated.** `bblocks-places` is no longer maintained. `0.0.6` is the final release.
+> Please migrate to [resolvekit](https://pypi.org/project/resolvekit/), which covers the
+> same place-resolution functionality and is under active development.
+
 # `bblocks-places`
 
-__Resolve and standardize places and work with political and geographic groupings.__
+**Resolve and standardize places and work with political and geographic groupings.**
 
 [![GitHub Repo](https://img.shields.io/badge/GitHub-bblocks_places-181717?style=flat-square&labelColor=%23ddd&logo=github&color=%23555&logoColor=%23000)](https://github.com/ONEcampaign/bblocks-places)
 [![GitHub License](https://img.shields.io/github/license/ONEcampaign/bblocks-places?style=flat-square&labelColor=%23ddd)](https://github.com/ONEcampaign/bblocks_places/blob/main/LICENSE)
 [![PyPI - Version](https://img.shields.io/pypi/v/bblocks_places?style=flat-square&labelColor=%23ddd)](https://pypi.org/project/bblocks_places/)
 [![Codecov](https://img.shields.io/codecov/c/github/ONEcampaign/bblocks-places?style=flat-square&labelColor=ddd)](https://codecov.io/gh/ONEcampaign/bblocks-places)
 
-
-Working with country data can be tedious. One source calls it “_South Korea_” another 
+Working with country data can be tedious. One source calls it “_South Korea_” another
 says “_Republic of Korea_” a third uses “_KOR_” — and suddenly your analysis breaks and you spend
-hours manually standardizing all the names. These inconsistencies are common in cross-geographic datasets and can lead to data 
+hours manually standardizing all the names. These inconsistencies are common in cross-geographic datasets and can lead to data
 cleaning headaches, merge errors, or misleading conclusions.
 
-`bblocks-places` eliminates this hassle by offering a simple, reliable interface to resolve, standardize, 
-and work with country, region, and other place names. 
+`bblocks-places` eliminates this hassle by offering a simple, reliable interface to resolve, standardize,
+and work with country, region, and other place names.
 
-__Key features__:
+**Key features**:
 
 - Disambiguate and standardize free-text country names (e.g. "Ivory Coast" → “Côte d’Ivoire”)
 - Convert between place formats like ISO codes and official names
 - Filter and retrieve countries by attributes like region, income group, or UN membership
 - Customize resolution logic with your own concordance or override mappings
 
-
-__Built on top of Google's [Data Commons](https://datacommons.org/)__, 
+**Built on top of Google's [Data Commons](https://datacommons.org/)**,
 an open knowledge graph integrating public data from the UN, World Bank, and more.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bblocks-places"
-version = "0.0.5"
+version = "0.0.6"
 description = "Resolve and standardize places and work with political and geographic groupings"
 authors = [
     {name = "ONE Campaign"},
@@ -9,6 +9,9 @@ authors = [
 license = {text = "MIT"}
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
+classifiers = [
+    "Development Status :: 7 - Inactive",
+]
 dependencies = [
     "datacommons-client (>=2.0.0,<3.0.0)",
     "pandas (>=2.2.3,<3.0.0)",

--- a/src/bblocks/places/__init__.py
+++ b/src/bblocks/places/__init__.py
@@ -1,4 +1,16 @@
+import warnings
 from importlib.metadata import version
+
+warnings.warn(
+    "bblocks-places is deprecated and no longer maintained. "
+    "It will not receive further updates or bug fixes. "
+    "Please migrate to resolvekit (https://pypi.org/project/resolvekit/), "
+    "which covers the same place-resolution functionality and is under "
+    "active development.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from bblocks.places.resolver import PlaceResolver
 
 from bblocks.places.main import (


### PR DESCRIPTION
`bblocks-places` is retired in favour of [resolvekit](https://pypi.org/project/resolvekit/), which covers the same place-resolution ground and is further along at 0.1.12 against this package's 0.0.5. Nothing in the local repo set depends on it, `bblocks` included, so this is a clean retirement rather than a migration with downstream breakage.

Importing the package now emits a `DeprecationWarning` naming resolvekit. It sits in `src/bblocks/places/__init__.py`, the sole entry point through which every public symbol is re-exported, so it fires exactly once per process however the package is reached. Nothing else changes, and 0.0.6 behaves identically for anyone who ignores the warning. The same notice goes at the top of `README.md` and the docs landing page, with a matching changelog entry, and `Development Status :: 7 - Inactive` is added to the package metadata so the retirement is visible on the PyPI page itself rather than only to people who open the repo.

The package stays on Poetry. Migrating it to uv would be effort spent on something being switched off.

Two things a reviewer should know. The markdown diff is wider than the change itself, because an editor-side formatter normalised trailing whitespace and `__bold__` into `**bold**` across every file touched; none of that is semantic. Separately, `requirements-dev.txt` is unsatisfiable against the current `pyproject.toml`, which predates this branch and is left alone.

Archiving the GitHub repository is deliberately not part of this, since that is a decision to make after the final release ships.

Testing: 182 tests pass. The warning was confirmed to fire exactly once in a fresh interpreter under `-W always::DeprecationWarning`, and `resolve_places(['zimbabwe', ' Italy ', 'USA', "Cote d'ivoire"])` still returns `['ZWE', 'ITA', 'USA', 'CIV']` against the live Data Commons API. The new classifier was validated against the `trove-classifiers` list rather than assumed valid.
